### PR TITLE
Speedup int32 vector reading

### DIFF
--- a/kaldi_io.py
+++ b/kaldi_io.py
@@ -102,9 +102,10 @@ def read_vec_int(file_or_fd):
   if binary == '\0B': # binary flag
     assert(fd.read(1) == '\4'); # int-size
     vec_size = struct.unpack('<i', fd.read(4))[0] # vector dim
-    # Vectors are structred as (LENGTHOFPOST,VALUE) 
-    vec = np.fromfile(fd,dtype=[('lenpost',np.int8),('post','<i')],count=vec_size)
-    ans = vec[:]['post']
+    # Elements from int32 vector are sored in tuples: (sizeof(int32), value),
+    vec = np.fromfile(fd, dtype=[('size',np.int8),('value','<i4')], count=vec_size)
+    assert(vec[0]['size'] == 4) # int32 size,
+    ans = vec[:]['value'] # values are in 2nd column,
   else: # ascii,
     arr = (binary + fd.readline()).strip().split()
     try:

--- a/kaldi_io.py
+++ b/kaldi_io.py
@@ -102,11 +102,9 @@ def read_vec_int(file_or_fd):
   if binary == '\0B': # binary flag
     assert(fd.read(1) == '\4'); # int-size
     vec_size = struct.unpack('<i', fd.read(4))[0] # vector dim
-    ans = np.zeros(vec_size, dtype=int)
-    for i in range(vec_size):
-      assert(fd.read(1) == '\4'); # int-size
-      ans[i] = struct.unpack('<i', fd.read(4))[0] #data
-    return ans
+    # Vectors are structred as (LENGTHOFPOST,VALUE) 
+    vec = np.fromfile(fd,dtype=[('lenpost',np.int8),('post','i4')],count=vec_size)
+    ans = vec[:]['post']
   else: # ascii,
     arr = (binary + fd.readline()).strip().split()
     try:

--- a/kaldi_io.py
+++ b/kaldi_io.py
@@ -103,7 +103,7 @@ def read_vec_int(file_or_fd):
     assert(fd.read(1) == '\4'); # int-size
     vec_size = struct.unpack('<i', fd.read(4))[0] # vector dim
     # Vectors are structred as (LENGTHOFPOST,VALUE) 
-    vec = np.fromfile(fd,dtype=[('lenpost',np.int8),('post','i4')],count=vec_size)
+    vec = np.fromfile(fd,dtype=[('lenpost',np.int8),('post','<i')],count=vec_size)
     ans = vec[:]['post']
   else: # ascii,
     arr = (binary + fd.readline()).strip().split()


### PR DESCRIPTION
Hey there,
I am currently using your codebase for kaldi-based experiments and noticed that my label reading (from ali-to-pdf) process was painfully slow (e.g. for switchboard dataset it takes me 2 minutes to read the labels). 

I found the reason, which was a sequential read in read_vec_int_ark. I replaced that with a numpy.fromfile.

On my local machine that sped up the loading process by ~ 30 - 40 times.