### PR TITLE
When reading empty vector, do not throw an exception

### DIFF
--- a/kaldi_io.py
+++ b/kaldi_io.py
@@ -272,7 +272,7 @@ def _read_vec_flt_binary(fd):
   assert (fd.read(1).decode() == '\4'); # int-size
   vec_size = np.frombuffer(fd.read(4), dtype='int32', count=1)[0] # vector dim
   if vec_size == 0:
-    return np.array([], dtype='int32')
+    return np.array([], dtype='float32')
   # Read whole vector,
   buf = fd.read(vec_size * sample_size)
   if sample_size == 4 : ans = np.frombuffer(buf, dtype='float32')


### PR DESCRIPTION
It is useful when the data is not well prepared (for example in CTC training, speech with an empty label sequence could be detected and properly skipped, instead of throwing an exception) and this behavior is consistent with Kaldi (such as ReadIntegerVector() in io-funcs-inl.h and Read() in kaldi-vector.cc)