### PR TITLE
Add read_scp_raw to kaldi_io

### DIFF
--- a/kaldi_io/kaldi_io.py
+++ b/kaldi_io/kaldi_io.py
@@ -383,6 +383,29 @@ def read_mat(file_or_fd):
         if fd is not file_or_fd: fd.close()
     return mat
 
+
+def read_scp_raw(text):
+    """
+    Parameters:
+    ------------
+    text: str
+        scp formatted string
+
+    Returns:
+    ------------
+    key: str
+        ark file's identifier
+    mat: array
+        ark vector corresponding to the audio sample
+    Example:
+    -----------
+    key, mat = read_scp_raw(
+        AMI_ES2011a_H00_FEE041_0003427_0003714 tests/data/feats_ascii.ark:39)
+    """
+    key, rxfile = text.split()
+    return key, read_mat(rxfile)
+
+
 def _read_mat_binary(fd):
     # Data type
     header = fd.read(3).decode()
@@ -401,6 +424,7 @@ def _read_mat_binary(fd):
     else : raise BadSampleSize
     mat = np.reshape(vec,(rows,cols))
     return mat
+
 
 def _read_mat_ascii(fd):
     rows = []

--- a/tests/test_kaldi_io.py
+++ b/tests/test_kaldi_io.py
@@ -76,6 +76,15 @@ class KaldiIoTest(unittest.TestCase):
             i32_vec3 = { k:v for k,v in kaldi_io.read_vec_int_ark('ark:copy-int-vector ark:tests/data/ali.ark ark:- |') }
             flt_vec4 = { k:v for k,v in kaldi_io.read_vec_flt_ark('ark:copy-vector ark:tests/data/conf.ark ark:- |') }
 
+    def testReadRawSCP(self):
+        """
+        Test read for raw scp strings
+        """
+        correct_vec = kaldi_io.read_mat('tests/data/feats_ascii.ark:39')
+        eg_text = 'AMI_ES2011a_H00_FEE041_0003427_0003714 tests/data/feats_ascii.ark:39'
+        key, mat = kaldi_io.read_scp_raw(eg_text)
+        assert mat.all() == correct_vec.all()
+
 
 # if stand-alone, run this...
 if __name__ == '__main__':


### PR DESCRIPTION
Hi @vesis84,

Thanks for the awesome wrapper first of all. It covers almost all the ways one could possibly use to read kaldi vectors. Maybe I missed something but I did not find a method that gives vectors directly based on raw scp text like -- "AMI_ES2011a_H00_FEE041_0003427_0003714 tests/data/feats_ascii.ark:39"

It's a really trivial addition but I thought it would help to have it. So I created this PR. Let me know if some method is doing exactly what I have implemented in `read_scp_raw`.