### PR TITLE
Update kaldi_io.py

### DIFF
--- a/kaldi_io/kaldi_io.py
+++ b/kaldi_io/kaldi_io.py
@@ -343,6 +343,7 @@ def write_vec_flt(file_or_fd, v, key=''):
 # Float matrices (features, transformations, ...),
 
 # Reading,
+            
 def read_mat_scp(file_or_fd):
     """ generator(key,mat) = read_mat_scp(file_or_fd)
      Returns generator of (key,matrix) tuples, read according to kaldi scp.
@@ -356,8 +357,11 @@ def read_mat_scp(file_or_fd):
      d = { key:mat for key,mat in kaldi_io.read_mat_scp(file) }
     """
     fd = open_or_fd(file_or_fd)
-    try:
-        for line in fd:
+    cnt_success = 0
+    cnt_broken = 0
+    
+    for line in fd:
+        try:
             (key, rxfile) = line.decode().split(' ')
             (rxfile, range_slice) = _strip_mat_range(rxfile)
 
@@ -365,11 +369,14 @@ def read_mat_scp(file_or_fd):
             # A faster solution would be to change API of read_mat() and load just the frames we need...
             mat = read_mat(rxfile)
             if range_slice is not None: mat = (mat[range_slice]).copy() # apply the range_slice,
-            #
-
+            cnt_success = cnt_success + 1
             yield key, mat
-    finally:
-        if fd is not file_or_fd : fd.close()
+        except:
+            print('Error: ', key)
+            cnt_broken = cnt_broken + 1
+    
+    print('Count success reads: {}, count broken files: {}'.format(cnt_success, cnt_broken))
+    if fd is not file_or_fd: fd.close()
 
 def read_mat_ark(file_or_fd):
     """ generator(key,mat) = read_mat_ark(file_or_fd)


### PR DESCRIPTION
If the file is empty the reading is not proceeded starting from the next bit, the whole file is skipped starting from the failing bit. Exception catching is added in a bit dirty way, so that when there is an empty file, it is skipped and the read proceeds to the next file.